### PR TITLE
Fix creating trade offer when no player items are requested

### DIFF
--- a/Modules/Source/ASteambot_Core.sp
+++ b/Modules/Source/ASteambot_Core.sp
@@ -272,6 +272,10 @@ public int Native_CreateTradeOffer(Handle plugin, int numParams)
 			StrCat(message, sizeof(message), item);
 		}
 	}
+	else
+	{
+		StrCat(message, sizeof(message), "NULL");
+	}
 	
 	StrCat(message, sizeof(message), "/");
 	


### PR DESCRIPTION
Add NULL to the offer message if we are not requesting items from the player